### PR TITLE
Add Google Analytics (GA4) tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Oliver Searle-Barnes CV</title>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZFTSMKN3FJ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-ZFTSMKN3FJ');
+  </script>
   <script type="module" src="/src/index.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Adds the GA4 gtag.js snippet to `index.html`
- Measurement ID: `G-ZFTSMKN3FJ` (property `opsb.co.uk`, account `opsb.co.uk`)

## Test plan
- [ ] Merge → GitHub Pages workflow deploys to https://opsb.co.uk/
- [ ] Visit the live site and confirm a request fires to `googletagmanager.com/gtag/js?id=G-ZFTSMKN3FJ`
- [ ] Confirm the visit appears in GA4 Realtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)